### PR TITLE
switched to count in order to avoid dependency issue

### DIFF
--- a/examples/test_azure_uc/.terraform.lock.hcl
+++ b/examples/test_azure_uc/.terraform.lock.hcl
@@ -1,26 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/azure/azapi" {
-  version     = "1.0.0"
-  constraints = ">= 1.0.0"
-  hashes = [
-    "h1:fcPmJwSGSirInxIwvfwQee+XpwFzuIbEzJfTXz0uoK0=",
-    "zh:01a33aaefe4d185e70d926103eeb0ac9fefeadf750f69c5977ead2ae02e0b038",
-    "zh:1ce767851be07e432b4cdde91b40beef84f030432bb7b431ffda85b89305414d",
-    "zh:1cf15bc8430377091c06373c74a68ce61a9f36dd1455929a64e8083332f2c291",
-    "zh:4372f59b2761b3ae4b59d59f978af547cd8fae44d2b2e5baa91735b0ea3b16e2",
-    "zh:6602e2aae7937456418f53372d7139d2f56aea5e46dfd46634f9b202988178c0",
-    "zh:6f0945ee6ae05cbd708c10ee7b0f8c987032e35122a01d661188538f7548e59f",
-    "zh:6fc5e5017b8f87aff48732cc619f1295175913e3c1c039a170e8f0100a8233a2",
-    "zh:740f6c339f28406988204af6fadc9e58c754a22f234902b34c1f6d54421476c2",
-    "zh:7f003da3b64cb5129627b96a5eb0a03113853a0b17fd4cb77bd505fd27a8ca0b",
-    "zh:a1ed7aa209cdee91b013691ddb61d77eb3d840f9cba2f4c8b923ba80823c5912",
-    "zh:d6dad27af147a127027a8aa08a259f6dc418b09f842620e56e5db85547b1b090",
-    "zh:e67ddb150ff40cf9453fd56f47c2ac657ede1c1861b4d2f9009e98bddfc345b2",
-  ]
-}
-
 provider "registry.terraform.io/databricks/databricks" {
   version     = "1.6.5"
   constraints = ">= 1.6.4"

--- a/examples/test_azure_uc/external_data.tf
+++ b/examples/test_azure_uc/external_data.tf
@@ -1,7 +1,7 @@
 resource "azurerm_databricks_access_connector" "ext_access_connector" {
   name                = "ext-databricks-mi"
-  resource_group_name = data.azurerm_resource_group.this.name
-  location            = data.azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
   identity {
     type = "SystemAssigned"
   }

--- a/modules/azure_uc/main.tf
+++ b/modules/azure_uc/main.tf
@@ -63,8 +63,8 @@ resource "databricks_metastore_data_access" "first" {
 }
 
 resource "databricks_metastore_assignment" "this" {
-  for_each = toset(var.workspaces_to_associate)
+  count = length(var.workspaces_to_associate)
 
-  workspace_id = each.key
+  workspace_id = var.workspaces_to_associate[count.index]
   metastore_id = databricks_metastore.this.id
 }


### PR DESCRIPTION
`for_each` was causing problems with the metastore assignment in the UC module and it really didn't need to be there - switched to `count`.